### PR TITLE
[TASK] Move TCA from ext_tables to the tt_content override folder

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,15 @@
+<?php
+
+$additionalTtContentFields = [
+    'tx_ncstaticfilecache_cache' => [
+        'exclude' => 0,
+        'label' => 'LLL:EXT:nc_staticfilecache/Resources/Private/Language/locallang.xml:nc_staticfilecache.field',
+        'config' => [
+            'type' => 'check',
+            'default' => '1',
+        ],
+    ],
+];
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalTtContentFields);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_ncstaticfilecache_cache;;;;1-1-1');

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -8,20 +8,6 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-$tmp = [
-    'tx_ncstaticfilecache_cache' => [
-        'exclude' => 0,
-        'label' => 'LLL:EXT:nc_staticfilecache/Resources/Private/Language/locallang.xml:nc_staticfilecache.field',
-        'config' => [
-            'type' => 'check',
-            'default' => '1',
-        ],
-    ],
-];
-
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $tmp);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_ncstaticfilecache_cache;;;;1-1-1');
-
 if (TYPO3_MODE == 'BE') {
     // Add Web>Info module:
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::insertModuleFunction('web_info',


### PR DESCRIPTION
The TCA is actually in the ext_tables.php. If you want to override the settings (the exclude for instance) you need to do some TCA post processing with a hook.
So why not create a Configurations/TCA/Overrides folder and put the TCA stuff in tt_content.php to make it easier for people to adjust the TCA fields.